### PR TITLE
Defining a connection URL syntax and method of connection

### DIFF
--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -1229,7 +1229,7 @@ content over the range specified.
 If 't' is omitted, then the URL is assumed to point at a catalog, in which case the track
 name is automatically 'catalog'.
 If 'ns' and 't' are omitted, then the player is assumed to have out-of-band information
-for accessing tracks and the URL purely defines the connection to the delivery network. 
+for accessing tracks and the URL purely defines the connection to the delivery network.
 
 Example query args
 * wallclock-range=1761759637565-1761759836189
@@ -1250,7 +1250,7 @@ Example URLs
   moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&c4m=gqhkYWxnIGVzaGFyqGR0eXB
   lY2NhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5uZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2NzgwMHZpc3VlZF9hdD0xN
   zMwNDM4NDAw
- 
+
 ### Connection using WebTransport
 Assuming a WARP URL of
 

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -1254,9 +1254,9 @@ Example URLs
 ### Connection using WebTransport
 Assuming a WARP URL of
 
-  moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&c4m=gqhkYWxnIGVzaGFyqGR0eXB
-  lY2NhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5uZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2NzgwMHZpc3VlZF9hdD0xN
-  zMwNDM4NDAw
+  moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&c4m=gqhkYWxnIGVzaGFyqGR0
+  eXBNhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5uZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2Nzgw
+  MHZpc3VlZF9hdD0xNzMwNDM4NDAw
 
 1. The player generates the WebTransport URL by substituting https for moqt and stripping off
    all query args. The token bytes are extracted and stored separately.

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -1177,7 +1177,7 @@ A WARP URL is a String with the following components
 
 moqt:// + authority + path + query
 
-* THe URL MUST conform with {{RFC3986}}.
+* The URL MUST conform with {{RFC3986}}.
 * The protocol is moqt and is required.
 * The authority is required and holds the host and optional port. The default port
   will be 443. The authority holds the information needed for the client to connect
@@ -1247,16 +1247,16 @@ Example URLs
   moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&location-range=34-0-64-16
 
 * URL pointing at a catalog and supplying a token
-  moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&c4m=gqhkYWxnIGVzaGFyqGR0
-  eXBNhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5uZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2Nzgw
-  MHZpc3VlZF9hdD0xNzMwNDM4NDAw
+  moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&c4m=gqhkYWxnIGV
+  zaGFyqGR0eXBNhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5uZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2
+  NzgwMHZpc3VlZF9hdD0xNzMwNDM4NDAw
 
 ### Connection using WebTransport
 Assuming a WARP URL of
 
-  moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&c4m=gqhkYWxnIGVzaGFyqGR0
-  eXBNhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5uZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2Nzgw
-  MHZpc3VlZF9hdD0xNzMwNDM4NDAw
+moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&c4m=gqhkYWxnIGV
+zaGFyqGR0eXBNhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5uZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2
+NzgwMHZpc3VlZF9hdD0xNzMwNDM4NDAw
 
 1. The player generates the WebTransport URL by substituting https for moqt and stripping off
    all query args. The token bytes are extracted and stored separately.
@@ -1269,9 +1269,9 @@ Assuming a WARP URL of
 ### Connection using raw QUIC
 Assuming a WARP URL of
 
-  moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&c4m=gqhkYWxnIGVzaGFyqGR0
-  eXBNhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5uZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2Nzgw
-  MHZpc3VlZF9hdD0xNzMwNDM4NDAw
+moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&c4m=gqhkYWxnIGV
+zaGFyqGR0eXBNhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5uZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2
+NzgwMHZpc3VlZF9hdD0xNzMwNDM4NDAw
 
 1. The player generates the AUTHORITY value of 'example.com' by stripping off the protocol,
    path and query components from the WARp URL. The token bytes are extracted and stored separately.

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -1247,16 +1247,16 @@ Example URLs
   moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&location-range=34-0-64-16
 
 * URL pointing at a catalog and supplying a token
-  moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&c4m=gqhkYWxnIGV
-  zaGFyqGR0eXBNhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5uZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2
-  NzgwMHZpc3VlZF9hdD0xNzMwNDM4NDAw
+  moqt://example.com/relay-app/relayID?ns=customerID/broadcastID
+  &c4m=gqhkYWxnIGVzaGFyqGR0eXBNhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5u
+  ZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2NzgwMHZpc3VlZF9hdD0xNzMwNDM
 
 ### Connection using WebTransport
 Assuming a WARP URL of
 
-moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&c4m=gqhkYWxnIGV
-zaGFyqGR0eXBNhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5uZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2
-NzgwMHZpc3VlZF9hdD0xNzMwNDM4NDAw
+moqt://example.com/relay-app/relayID?ns=customerID/broadcastID
+&c4m=gqhkYWxnIGVzaGFyqGR0eXBNhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5u
+ZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2NzgwMHZpc3VlZF9hdD0xNzMwNDM
 
 1. The player generates the WebTransport URL by substituting https for moqt and stripping off
    all query args. The token bytes are extracted and stored separately.
@@ -1269,9 +1269,9 @@ NzgwMHZpc3VlZF9hdD0xNzMwNDM4NDAw
 ### Connection using raw QUIC
 Assuming a WARP URL of
 
-moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&c4m=gqhkYWxnIGV
-zaGFyqGR0eXBNhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5uZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2
-NzgwMHZpc3VlZF9hdD0xNzMwNDM4NDAw
+moqt://example.com/relay-app/relayID?ns=customerID/broadcastID
+&c4m=gqhkYWxnIGVzaGFyqGR0eXBNhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5u
+ZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2NzgwMHZpc3VlZF9hdD0xNzMwNDM
 
 1. The player generates the AUTHORITY value of 'example.com' by stripping off the protocol,
    path and query components from the WARp URL. The token bytes are extracted and stored separately.

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -1247,9 +1247,9 @@ Example URLs
   moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&location-range=34-0-64-16
 
 * URL pointing at a catalog and supplying a token
-  moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&c4m=gqhkYWxnIGVzaGFyqGR0eXB
-  lY2NhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5uZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2NzgwMHZpc3VlZF9hdD0xN
-  zMwNDM4NDAw
+  moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&c4m=gqhkYWxnIGVzaGFyqGR0
+  eXBNhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5uZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2Nzgw
+  MHZpc3VlZF9hdD0xNzMwNDM4NDAw
 
 ### Connection using WebTransport
 Assuming a WARP URL of

--- a/draft-ietf-moq-warp.md
+++ b/draft-ietf-moq-warp.md
@@ -1269,9 +1269,9 @@ Assuming a WARP URL of
 ### Connection using raw QUIC
 Assuming a WARP URL of
 
-  moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&c4m=gqhkYWxnIGVzaGFyqGR0eXB
-  lY2NhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5uZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2NzgwMHZpc3VlZF9hdD0xN
-  zMwNDM4NDAw
+  moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&c4m=gqhkYWxnIGVzaGFyqGR0
+  eXBNhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5uZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2Nzgw
+  MHZpc3VlZF9hdD0xNzMwNDM4NDAw
 
 1. The player generates the AUTHORITY value of 'example.com' by stripping off the protocol,
    path and query components from the WARp URL. The token bytes are extracted and stored separately.


### PR DESCRIPTION
Defines a URL syntax along with methods of connecting over WebTransport and raw QUIC. 

Example URLs
* URL pointing at a catalog
`  moqt://example.com/relay-app/relayID?ns=customerID/broadcastID`

* URL pointing at a non-catalog track
 ` moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&t=video`

* URL pointing at a subclip of a catalog
`  moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&location-range=34-0-64-16`

* URL pointing at a catalog and supplying a token
```
  moqt://example.com/relay-app/relayID?ns=customerID/broadcastID&c4m=gqhkYWxnIGVzaGFyqGR0eXB
  lY2NhdZ9hdWQAY3VybGZlbWlzcwZleWV2aW5uZWlhdGVwQWNyZW5lYnJmcmVqMTIzNDU2NzgwMHZpc3VlZF9hdD0xN
  zMwNDM4NDAw
```

Fixes #60 